### PR TITLE
Remove panic in case of an unknown error

### DIFF
--- a/request.go
+++ b/request.go
@@ -249,7 +249,7 @@ func (wepr *WebEnrollmentPendingRequest) Submit() (WebEnrollmentResponse, error)
 	case UNAUTHORIZED:
 		return WebEnrollmentResponse{}, errors.New("Unauthorized: Access is denied")
 	case FAIL:
-		fallthrough
+		return WebEnrollmentResponse{}, fmt.Errorf("Fail: Unknown error has occurred")
 	default:
 		// need to try and establish what went wrong here
 		panic("The request failed and i do not know why")


### PR DESCRIPTION
This is necessary so that in the event of an error, the behavior of the library does not change, and this error can be handled uniformly, as is usually done with errors.