### PR TITLE
Add status for denied request

### DIFF
--- a/request.go
+++ b/request.go
@@ -102,6 +102,8 @@ func (wer *WebEnrollmentNewRequest) Submit() (WebEnrollmentResponse, error) {
 		response.requestid = wer.parsePendingRequestNumber(respbody.String())
 	case UNAUTHORIZED:
 		return WebEnrollmentResponse{}, errors.New("Access is denied due to invalid credentials")
+	case DENIED:
+		return WebEnrollmentResponse{}, errors.New("request was denied")
 	case FAIL:
 		fallthrough
 	default:
@@ -139,6 +141,7 @@ func (wer WebEnrollmentNewRequest) parseSuccessStatus(resp []byte) int {
 	issued := regexp.MustCompile("Certificate Issued")
 	pending := regexp.MustCompile("Your certificate request has been received.")
 	unauthorized := regexp.MustCompile("Unauthorized: Access is denied due to invalid credentials.")
+	denied := regexp.MustCompile("Your certificate request was denied.")
 
 	if issued.Match(resp) {
 		returndata = SUCCESS
@@ -146,6 +149,8 @@ func (wer WebEnrollmentNewRequest) parseSuccessStatus(resp []byte) int {
 		returndata = PENDING
 	} else if unauthorized.Match(resp) {
 		returndata = UNAUTHORIZED
+	} else if denied.Match(resp) {
+		returndata = DENIED
 	} else {
 		returndata = FAIL
 	}

--- a/response.go
+++ b/response.go
@@ -9,6 +9,8 @@ const (
 	UNAUTHORIZED = 2
 	// FAIL status
 	FAIL = 3
+	// DENIED status
+	DENIED = 4
 )
 
 // WebEnrollmentResponse struct contains the parsed response from adcs


### PR DESCRIPTION
Handle "Your certificate request was denied." response from server, possibly from incorrectly configured template.